### PR TITLE
Fix accessibility in SVG & remove `main` for NPM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.0.16] - 2023-05-28
+
+### Fixed
+- `<svg>` child elements no longer have default `role` attribute
+- Package no longer has a `main`
+
 ## [v0.0.15] - 2023-05-28
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,9 +1,8 @@
 {
   "name": "@shgysk8zer0/kazoo",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "private": false,
   "description": "A JavaScript monorepo for all the things!",
-  "main": "index.js",
   "config": {
     "serve": {
       "domain": "localhost",

--- a/svg.js
+++ b/svg.js
@@ -20,7 +20,7 @@ export function createSVGFile(svg, { name = 'image.svg' } = {}) {
 
 export function createSVGElement (tag, {
 	fill, stroke, width, height, pathLength, children = [], id, classList = [],
-	styles, dataset, role = DEFAULT_ROLE, ariaLabel,
+	styles, dataset, role, ariaLabel,
 	events: {
 		capture,
 		passive,
@@ -123,9 +123,9 @@ export function createSVG({
 	viewBox = null,
 	height = null,
 	width = null,
-	label = null,
 	slot = null,
 	role = DEFAULT_ROLE,
+	ariaLabel,
 	hidden = false,
 	classList = [],
 	children = [],
@@ -144,8 +144,8 @@ export function createSVG({
 		svg.setAttributeNS(null, 'viewBox', viewBox.map(n => n.toString()).join(' '));
 	}
 
-	if (typeof label === 'string') {
-		svg.setAttribute('aria-label', label);
+	if (typeof ariaLabel === 'string') {
+		svg.setAttribute('aria-label', ariaLabel);
 	}
 
 	if (hidden === true) {

--- a/test/js/index.js
+++ b/test/js/index.js
@@ -47,7 +47,8 @@ document.getElementById('footer').append(
 getJSON('./api/bacon.json').then(async lines => {
 	html('#bacon', policy.createHTML(lines.map(t =>  `<p onclick="alert(1)">${t}</p>`).join('')));
 
-	document.getElementById('header').append(...Object.values(icons).map(func => func({ size: 64 })));
+	document.getElementById('header')
+		.append(...Object.entries(icons).map(([ariaLabel, func]) => func({ size: 64, ariaLabel })));
 
 	const list = createElement('ol', {
 		children: Iterator.range(0, Infinity)


### PR DESCRIPTION
- SVG child elemets no longer have default `role` attr
- Remove `main` in npm package config

# Description and issue

## List of significant changes made
-  
-  
