### PR TITLE
Deprecate use of Sanitizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.0.17] - 2023-06-23
+
 ### Added
 - Add `@shgysk8zer0/js-utils`
 
@@ -14,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Update GitHub Release Action with correct permissions
+
+### Changed
+- All sanitizer-related functions now accept config as well as sanitizer dict
+- Switch to using `el.setHTML()` & `Document.parseHTML()`
+
+### Deprecated
+- Sanitizer is deprecated and has been effectively removed from the spec
 
 ## [v0.0.16] - 2023-05-28
 

--- a/elements.js
+++ b/elements.js
@@ -75,6 +75,14 @@ export function createElement(tag, {
 	html                      = undefined,
 	policy                    = 'trustedTypes' in globalThis ? globalThis.trustedTypes.defaultPolicy : null,
 	sanitizer                 = undefined,
+	allowElements,
+	allowComments,
+	allowAttributes,
+	allowCustomElements,
+	blockElements,
+	dropAttributes,
+	dropElements,
+	allowUnknownMarkup,
 	aria                      = undefined,
 	events: { capture, passive, once, signal, ...events } = {},
 	animation: {
@@ -139,11 +147,17 @@ export function createElement(tag, {
 			el.textContent = text;
 		} else if (typeof html === 'string' || isHTML(html)) {
 			if (
-				'Sanitizer' in globalThis
-				&& sanitizer instanceof globalThis.Sanitizer
-				&& Element.prototype.setHTML instanceof Function
+				Element.prototype.setHTML instanceof Function
+				&& (
+					(typeof allowElements !== 'undefined' && typeof allowAttributes !== 'undefined')
+					|| ('Sanitizer' in globalThis && sanitizer instanceof globalThis.Sanitizer)
+				)
 			) {
-				el.setHTML(html, { sanitizer });
+				el.setHTML(html, {
+					allowElements, allowComments, allowAttributes,
+					allowCustomElements, blockElements, dropAttributes, dropElements,
+					allowUnknownMarkup, sanitizer,
+				});
 			} else {
 				setProp(el, 'innerHTML', html, { policy });
 			}
@@ -218,13 +232,12 @@ export function createSlot(name, {
 	text      = undefined,
 	html      = undefined,
 	policy    = undefined,
-	sanitizer = undefined,
 	events: { capture, passive, once, signal, ...events } = {},
-	...attrs
+	...rest
 } = {}) {
 	const slot = createElement('slot', {
 		id, classList, hidden, dataset, children, styles, text, html, policy,
-		sanitizer, events: { capture, passive, once, signal, ...events }, ...attrs,
+		events: { capture, passive, once, signal, ...events }, ...rest,
 	});
 
 	slot.name = name;

--- a/http.js
+++ b/http.js
@@ -229,9 +229,15 @@ export async function getHTML(url, {
 	keepalive = undefined,
 	signal = undefined,
 	timeout = null,
-	head = true,
-	asFrag = true,
 	sanitizer = undefined,
+	allowElements,
+	allowComments,
+	allowAttributes,
+	allowCustomElements,
+	blockElements,
+	dropAttributes,
+	dropElements,
+	allowUnknownMarkup,
 	policy,
 	errorMessage,
 } = {}) {
@@ -239,9 +245,18 @@ export async function getHTML(url, {
 		cache, redirect, priority, integrity, keepalive, signal, timeout, errorMessage });
 
 	if (isTrustPolicy(policy)) {
-		return parse(policy.createHTML(html), { asFrag, head });
+		const doc = new DOMParser().parseFromString(policy.createHTML(html), TYPES.HTML);
+		const frag = document.createDocumentFragment();
+		frag.append(...doc.head.children, ...doc.body.children);
+		return frag;
 	} else {
-		return parse(html, { head, asFrag, sanitizer, policy });
+		const frag = document.createDocumentFragment();
+		const doc = Document.parseHTML(html, {
+			sanitizer, allowElements, allowComments, allowAttributes, allowCustomElements,
+			blockElements, dropAttributes, dropElements, allowUnknownMarkup,
+		});
+		frag.append(...doc.head.children, ...doc.body.children);
+		return frag;
 	}
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shgysk8zer0/kazoo",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@shgysk8zer0/kazoo",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "license": "MIT",
       "devDependencies": {
         "@shgysk8zer0/js-utils": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shgysk8zer0/kazoo",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "private": false,
   "description": "A JavaScript monorepo for all the things!",
   "config": {

--- a/test/index.html
+++ b/test/index.html
@@ -9,8 +9,8 @@
 			base-uri 'self';
 			manifest-src 'self';
 			prefetch-src 'self';
-			script-src 'self' unpkg.com/ 'nonce-3b58877b-25c3-4af2-975f-76607bd7c78e';
-			style-src 'self' unpkg.com;
+			script-src 'self' https://unpkg.com/@shgysk8zer0/ https://unpkg.com/leaflet@1.9.3/ 'nonce-3b58877b-25c3-4af2-975f-76607bd7c78e';
+			style-src 'self' https://unpkg.com/@shgysk8zer0/ https://unpkg.com/leaflet@1.9.3/ blob:;
 			font-src cdn.kernvalley.us;
 			form-action 'none';
 			frame-src https://www.youtube-nocookie.com/embed/;
@@ -19,7 +19,7 @@
 			child-src 'self';
 			worker-src 'self';
 			frame-ancestors 'none';
-			connect-src 'self' unpkg.com/@shgysk8zer0/ cdn.kernvalley.us api.github.com/users/ api.github.com/repos/ api.pwnedpasswords.com/range/ maps.kernvalley.us/places/ events.kernvalley.us/events.json;
+			connect-src 'self' https://unpkg.com/@shgysk8zer0/ https://api.github.com/users/ https://api.github.com/repos/ https://api.pwnedpasswords.com/range/ https://maps.kernvalley.us/places/ https://events.kernvalley.us/events.json;
 			img-src * data: blob:;
 			require-trusted-types-for 'script';
 			trusted-types empty#html empty#script default sanitizer-raw#html youtube#embed github-user#html github-repo#html;
@@ -30,18 +30,19 @@
 		<script type="importmap" nonce="3b58877b-25c3-4af2-975f-76607bd7c78e">
 			{
 				"imports": {
-					"@shgysk8zer0/polyfills": "https://unpkg.com/@shgysk8zer0/polyfills@0.0.7/all.min.js",
-					"@shgysk8zer0/polyfills/": "https://unpkg.com/@shgysk8zer0/polyfills@0.0.7/",
-					"@shgysk8zer0/components/": "https://unpkg.com/@shgysk8zer0/components@0.0.8/",
-					"@shgysk8zer0/konami": "https://unpkg.com/@shgysk8zer0/konami@1.0.9/konami.js",
-					"@shgysk8zer0/kazoo/": "../",
+					"@shgysk8zer0/polyfills": "https://unpkg.com/@shgysk8zer0/polyfills@0.1.2/all.min.js",
+					"@shgysk8zer0/polyfills/": "https://unpkg.com/@shgysk8zer0/polyfills@0.1.2/",
+					"@shgysk8zer0/components/": "https://unpkg.com/@shgysk8zer0/components@0.0.9/",
+					"@shgysk8zer0/konami": "https://unpkg.com/@shgysk8zer0/konami@1.1.1/konami.js",
+					"@shgysk8zer0/jswaggersheets": "https://unpkg.com/@shgysk8zer0/jswaggersheets/swagger.js",
 					"@shgysk8zer0/http-status": "https://unpkg.com/@shgysk8zer0/http-status@1.0.1/http-status.js",
+					"@shgysk8zer0/kazoo/": "../",
 					"leaflet": "https://unpkg.com/leaflet@1.9.3/dist/leaflet-src.esm.js",
 					"firebase/": "https://www.gstatic.com/firebasejs/9.16.0/"
 				}
 			}
 		</script>
-		<script type="application/javascript" defer="" referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha384-6D7++ok/uTOBioRnypzDxJYKgBEgNUmmnNO1ZKJAUyA21GK1vuHmOsoGswvTN157" src="https://unpkg.com/@shgysk8zer0/polyfills@0.0.7/all.min.js" fetchpriority="auto"></script>
+		<script type="application/javascript" defer="" referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha384-8s5Tj7IrKDs3va2EJ3QsRxxApN9vT+thnbA8imc6bwYJA2JaAddVR5b8q5wDkrdv" src="https://unpkg.com/@shgysk8zer0/polyfills@0.1.2/all.min.js" fetchpriority="high"></script>
 		<script src="/harden.js" referrerpolicy="no-referrer" defer=""></script>
 		<script type="module" src="./js/index.js" referrerpolicy="no-referrer"></script>
 		<link rel="stylesheet" href="./css/index.css" referrerpolicy="no-referrer" media="all" />
@@ -52,6 +53,7 @@
 		<header id="header"></header>
 		<nav id="nav"></nav>
 		<main id="main">
+			<div data-template="./lorem.html"></div>
 			<form id="contact">
 				<input type="text" name="subject" id="subject" placeholder="Subject" />
 				<input type="url" name="url" id="url" placeholder="https://example.com" />

--- a/test/js/styles.js
+++ b/test/js/styles.js
@@ -1,0 +1,146 @@
+export const btnStyles = {
+	'.btn:not([hidden])': {
+		appearance: 'button',
+		display: 'inline-block',
+		padding: 'var(--button-padding, 0.3em)',
+		'font-family': 'var(--button-font, inherit)',
+		'border-radius': 'var(--button-border-radius, initial)',
+		'box-sizing': 'border-box',
+	},
+
+	'.btn.round': {
+		'border-radius': '50%',
+	},
+
+	'.btn.rounded, .btn.outline.rounded': {
+		'border-radius': 'var(--button-rounded-border-radius, 2em)',
+	},
+
+	':disabled, .disabled, [disabled], ._state--disabled': {
+		cursor: 'not-allowed',
+		'pointer-events': 'none',
+	},
+
+	'.btn:disabled, .btn.disabled, .btn._state--disabled': {
+		'box-shadow': '0 0 0.3rem var(--shadow-color, rgba(0,0,0,0.4)) inset',
+		'border': 'var(--button-disabled-border, var(--button-border, 0.2rem inset black))',
+	},
+
+	'.btn:focus, summary:focus, input:focus, select:focus, textarea:focus, .input:focus, [tabindex]:focus, a:focus': {
+		'outline-width': 'var(--focus-outline-width, thin)',
+		'outline-style': 'var(--focus-outline-style, dotted)',
+		'outline-color': 'var(--focus-outline-color, currentColor)',
+		'outline-offset': 'var(--focus-outline-offset, 0)',
+	},
+
+	'.btn.btn-primary': {
+		'background-color': 'var(--button-primary-background)',
+		border: 'var(--button-primary-border)',
+		color: 'var(--button-primary-color)',
+	},
+
+	'.btn.btn-primary:hover': {
+		'background-color': 'var(--button-primary-hover-background, var(--button-primary-active-background, var(--button-primary-background)))',
+		border: 'var(--button-primary-hover-border, var(--button-primary-active-border, var(--button-primary-border))))',
+		color: 'var(--button-primary-hover-color, var(--button-primary-active-color, var(--button-primary-color))))',
+	},
+
+	'.btn.btn-primary:active, .btn.btn-primary.active': {
+		'background-color': 'var(--button-primary-active-background, var(--button-primary-background))',
+		border: 'var(--button-primary-active-border, var(--button-primary-border))',
+		color: 'var(--button-primary-active-color)',
+	},
+
+	'.btn.btn-default': {
+		'background-color': 'var(--button-default-background, #DFDFDF)',
+		border: 'var(--button-default-border, initial)',
+		color: 'var(--button-default-color, #585858)',
+	},
+
+	'.btn.btn-default:hover': {
+		'background-color': 'var(--button-default-hover-background, var(--button-default-active-background, #CDCDCD))',
+		border: 'var(--button-default-hover-border, var(--button-default-active-border, initial))',
+		color: 'var(--button-default-hover-color, var(----button-default-active-color, #585858))',
+	},
+
+	'.btn.btn-default:active, .btn.btn-default.active': {
+		'background-color': 'var(--button-default-active-background, #CDCDCD)',
+		border: 'var(--button-default-active-border)',
+		color: 'var(--button-default-active-color, #585858)',
+	},
+
+	'.btn.btn-accept': {
+		'background-color': 'var(--button-accept-background, var(--button-primary-background))',
+		border: 'var(--button-accept-active-border, var(--button-primary-border))',
+		color: 'var(--button-accept-color, var(--button-primary-color))',
+	},
+
+	'.btn.btn-accept:hover': {
+		'background-color': 'var(--button-accept-hover-background, var(--button-accept-active-background, var(--button-primary-hover-background, var(--button-primary-active-background))))',
+		color: 'var(--button-accept-hover-color, var(--button-accept-active-color, var(--button-primary-hover-color, var(--button-primary-active-color, var(--button-primary-color)))))',
+		border: 'var(--button-accept-hover-border, var(--button-accept-active-border, var(--button-primary-hover-border, var(--button-primary-active-border, var(--button-primary-border)))))',
+	},
+
+	'.btn.btn-accept:disabled, .btn.btn-accept._state--disabled, .btn.btn-accept.disabled': {
+		'background-color': 'var(--button-accept-disabled-background, var(--button-accept-background, var(--button-disabled-background, var(--button-background,))))',
+		border: 'var(--button-accept-disabled-border, var(--button-accept-border, var(--button-disabled-border)))',
+		color: 'var(--button-accept-disabled-color, var(--button--accept-color, var(--button-disabled-color)))',
+	},
+
+	'.btn.btn-accept:active, .btn.btn-accept.active': {
+		'background-color': 'var(--button-accept-active-background, var(--button-accept-background))',
+		border: 'var(--button-accept-active-border, var(--button-accept-border, var(--button-primary-active-border)))',
+		color: 'var(--button-accept-active-color, var(--button--accept-color, var(--button-active-color)))',
+	},
+
+	'.btn.btn-reject': {
+		'background-color': 'var(--button-reject-background, var(--button-primary-background))',
+		'border': 'var(--button-reject-border, var(--button-primary-border))',
+		'color': 'var(--button-reject-color, var(--button-primary-color))',
+	},
+
+	'.btn.btn-reject:hover': {
+		'background-color': 'var(--button-reject-hover-background, var(--button-reject-active-background, var(--button-primary-hover-background, var(--button-primary-active-background))))',
+		border: 'var(--button-reject-hover-border, var(--button-reject-active-border, var(--button-primary-hover-border, var(--button-primary-active-border, var(--button-primary-border)))))',
+		color: 'var(--button-reject-hover-color, var(--button-reject-active-color, var(--button-primary-hover-color, var(--button-primary-active-color, var(--button-primary-color)))))',
+	},
+
+	'.btn.btn-reject:disabled, .btn.btn-reject._state--disabled, .btn.btn-reject.disabled, .btn.btn-reject[disabled]': {
+		'background-color': 'var(--button-reject-disabled-background, var(--button-reject-background, var(--button-disabled-background, var(--button-background))))',
+		border: 'var(--button-reject-disabled-border, var(--button-reject-border, var(--button-disabled-border)))',
+		color: 'var(--button-reject-disabled-color, var(--button--reject-color, var(--button-disabled-color)))',
+	},
+
+	'.btn.btn-reject:active, .btn.btn-reject.active': {
+		'background-color': 'var(--button-reject-active-background, var(--button-reject-background))',
+		border: 'var(--button-reject-active-border, var(--button-reject-border, var(--button-primary-active-border)))',
+		color: 'var(--button-reject-active-color, var(--button--reject-color, var(--button-active-color)))',
+	},
+
+	'.btn.btn-outline': {
+		color: 'var(--button-outline-color, var(--accent-color, #007bff))',
+		'background-color': 'var(--button-outline-background, transparent)',
+		border: 'var(--button-outline-border, 2px solid currentColor)',
+		'border-radius': 'var(--button-outline-border-radius, 12px)',
+	},
+
+	'.btn.btn-outline.accent': {
+		color: 'var(--button-outline-color, var(--accent-color, #007bff))',
+	},
+
+	'.btn.btn-outline.current-color': {
+		color: 'inherit',
+	},
+
+	'.btn.btn-outline.primary': {
+		color: 'var(--button-primary-background)',
+	},
+
+	'.btn.btn-outline.accept': {
+		color: 'var(--button-accept-background)',
+	},
+
+	'.btn.btn-outline.reject': {
+		color: 'var(--button-reject-background)',
+	},
+};

--- a/test/lorem.html
+++ b/test/lorem.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+	<body>
+		<p>Fugiat occaecati laborum suscipit repellat. Reiciendis et adipisci aut quia consequuntur. Iusto non harum quia est consequuntur fugit ipsa.</p>
+		<p>Magnam quo nostrum incidunt sed harum qui est. Quisquam quia et ad dolorum. Soluta commodi harum sed similique repellat. Consequuntur assumenda aut sit.</p>
+		<p>Eaque ex et sed autem alias. Doloribus explicabo fugiat ut. Odit ut labore qui omnis. Quisquam laborum voluptas vitae recusandae eum.</p>
+		<p>Deleniti deleniti libero consectetur labore sequi. Impedit voluptates quam libero. Labore qui explicabo provident voluptas saepe. Delectus et laborum voluptatem velit voluptatem cupiditate alias temporibus.</p>
+		<p>At eos tempora nam tenetur aliquid optio earum. Exercitationem vero cumque esse. Et magnam nesciunt natus repellat est. Aut officiis ipsa rerum. Quisquam reiciendis ut iure velit necessitatibus qui sint.</p>
+	</body>
+</html>

--- a/utility.js
+++ b/utility.js
@@ -412,3 +412,7 @@ export const toSpinalCase = str => str.replace(/[A-Z]/g, (m, i) => i === 0
 export const toCamelCase = str => str.replace(/-[a-z\d]/g, m => m.substr(1).toUpperCase());
 
 export const ucFirst = str => str.substr(0, 1).toUpperCase() + str.substr(1);
+
+export async function filterKeys(obj, keys) {
+	return Object.fromEntries(Object.entries(obj).filter(([key]) => keys.includes(key)));
+}


### PR DESCRIPTION
It still remains in use for the transition, but it has been maybe
removed from the spec. So swith to using `el.setHTML()` and
`Document.parseHTML()` with config objects.

# Description and issue

## List of significant changes made
-  
-  
