### PR TITLE
More misc. updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.1.0] - 2023-07-01
+
+### Added
+- Add `markdown` module
+- Add `isSafeHTML()` to `trust-policies` module (checks for unsafe elements & attributes)
+- Add `getCSSStyleSheet()` to `http` module
+- Add Markdown to `types` module
+- Add `gravatar` module
+
+### Changed
+- Rename `loadStylesheet()` -> `loadStyleSheet()` in `loader` module (with alias to old)
+- Update importmap and trusted policies
+
+### Deprecated
+- `loadStylesheet()` is deprecated
+
 ## [v0.0.17] - 2023-06-23
 
 ### Added

--- a/gravatar.js
+++ b/gravatar.js
@@ -1,0 +1,35 @@
+import { md5 } from './hash.js';
+import { createImage } from './elements.js';
+
+export async function createGravatarURL(email, { size = 256 } = {}) {
+	const hash = await md5(email);
+	const url = new URL(hash, 'https://secure.gravatar.com/avatar/');
+	url.searchParams.set('s', size);
+	url.searchParams.set('d', 'mm');
+	return url;
+}
+
+export async function createGravatar(email, {
+	size = 256,
+	alt = '',
+	id,
+	classList = [],
+	part = [],
+	loading = 'lazy',
+	fetchPriority = 'auto',
+	decoding = 'async',
+	crossOrigin = 'anonymous',
+	referrerPolicy = 'no-referrer',
+	itemprop = null,
+	animation,
+	aria,
+	events,
+	dataset,
+} = {}) {
+	const url = await createGravatarURL(email, { size });
+
+	return createImage(url, {
+		height: size, width: size, alt, classList, part, loading, fetchPriority, aria,
+		crossOrigin, referrerPolicy, decoding, itemprop, animation, events, dataset, id,
+	});
+}

--- a/http.js
+++ b/http.js
@@ -490,6 +490,33 @@ export function navigateTo(to, {
 	}
 }
 
+export async function getCSSStyleSheet(url, {
+	mode = 'cors',
+	cache = 'default',
+	credentials = 'omit',
+	redirect = 'follow',
+	priority = 'auto',
+	referrerPolicy = 'no-referrer',
+	media,
+	disabled = false,
+	baseURL = document.baseURI,
+	signal,
+} = {}) {
+	const resp = await fetch(url, {
+		headers: new Headers({ Accept: TYPES.CSS }),
+		mode, cache, credentials, redirect,  priority, referrerPolicy, signal,
+	});
+
+	if (! resp.ok) {
+		throw new Error(`${resp.url} [${resp.status} ${resp.statusText}]`);
+	} else if (! resp.headers.get('Content-Type').startsWith(TYPES.CSS)) {
+		throw new TypeError(`Expected "Content-Type: ${TYPES.CSS}" but got ${resp.headers.get('Content-Type')}.`);
+	} else {
+		const css = await resp.text();
+		return new CSSStyleSheet({ media, disabled, baseURL }).replace(css);
+	}
+}
+
 export function postNav(url, data = {}, {
 	target = '_self' ,
 	enctype = TYPES.FORM_URL_ENCODED,

--- a/loader.js
+++ b/loader.js
@@ -162,7 +162,18 @@ export async function loadScript(src, {
 	return await promise;
 }
 
-export async function loadStylesheet(href, {
+/**
+ * @Deprecated
+ */
+export async function loadStylesheet(...args) {
+	if (location.hostname === 'localhost' || location.hostname.endsWith('.live')) {
+		console.warn('`loadStylesheet()` is deprecated and has been renamed to `loadStyleSheet()`.');
+	}
+
+	return loadStyleSheet(...args);
+}
+
+export async function loadStyleSheet(href, {
 	rel = 'stylesheet',
 	media = 'all',
 	blocking = null,

--- a/markdown.js
+++ b/markdown.js
@@ -1,0 +1,116 @@
+import { use, parse } from 'marked';
+import { markedHighlight } from 'marked-highlight';
+import hljs from 'highlight.js';
+import { MARKDOWN } from './types.js';
+
+export const STYLESHEETS = {
+	github: {
+		dark: {
+			href: `https://unpkg.com/highlight.js@${hljs.versionString}/styles/github-dark.css`,
+			media: 'screen and (prefers-color-scheme: dark)',
+		},
+		light: {
+			href: `https://unpkg.com/highlight.js@${hljs.versionString}/styles/github.css`,
+			media: 'print, not (prefers-color-scheme: dark)',
+		},
+	},
+};
+
+export const ALLOW_ELEMENTS = [
+	'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'blockquote', 'pre', 'code',
+	'table', 'thead', 'tbody', 'tr', 'th', 'td', 'a', 'img', 'ol', 'ul', 'li',
+	'i', 'b', 'u', 'strong', 'em', 'span', 'div', 'hr', 'br', 'sub', 'sup',
+];
+
+export const ALLOW_ATTRIBUTES = {
+	'href': ['a'],
+	'src': ['img'],
+	'alt': ['img'],
+	'id': ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
+	'class': ['*'],
+};
+
+use(markedHighlight({
+	langPrefix: 'hljs language-',
+	highlight(code, lang) {
+		const language = hljs.getLanguage(lang) ? lang : 'plaintext';
+		return hljs.highlight(code, { language }).value;
+	}
+}));
+
+export async function parseMarkdown(str, {
+	base = document.baseURI,
+	allowElements = ALLOW_ELEMENTS,
+	allowAttributes = ALLOW_ATTRIBUTES,
+} = {}) {
+	const { resolve, reject, promise } = Promise.withResolvers();
+
+	requestIdleCallback(() => {
+		try {
+			const parsed = parse(str);
+			const doc = Document.parseHTML(parsed, { allowElements, allowAttributes });
+			const frag = document.createDocumentFragment();
+
+			doc.querySelectorAll('img').forEach(img => {
+				img.loading = 'lazy';
+				img.crossOrigin = 'anonymous';
+				img.referrerPolicy = 'no-referrer';
+			});
+
+			doc.querySelectorAll('a').forEach(a => {
+				a.relList.add('external', 'noopener', 'noreferrer');
+				a.href = new URL(a.getAttribute('href'), base);
+			});
+
+			frag.append(...doc.body.children);
+			resolve(frag);
+		} catch(e) {
+			reject(e);
+		}
+	});
+
+	return promise;
+}
+
+export async function parseMarkdownFile(file, {
+	base = document.baseURI,
+	allowElements = ALLOW_ELEMENTS,
+	allowAttributes = ALLOW_ATTRIBUTES,
+} = {}) {
+	if (! (file instanceof File)) {
+		throw new TypeError('Not a file.');
+	} else if (file.type !== MARKDOWN) {
+		throw new TypeError(`${file.name} is not a markdown file.`);
+	} else {
+		const text = await file.text();
+		return await parseMarkdown(text, { base, allowElements, allowAttributes });
+	}
+}
+
+export async function fetchMarkdown(url, {
+	base = document.baseURI,
+	allowElements = ALLOW_ELEMENTS,
+	allowAttributes = ALLOW_ATTRIBUTES,
+	headers = {},
+	mode = 'cors',
+	cache = 'default',
+	credentials = 'omit',
+	redirect = 'follow',
+	priority = 'auto',
+	referrerPolicy = 'no-referrer',
+	signal,
+} = {}) {
+	const resp = await fetch(url, {
+		headers: new Headers({ Accept: MARKDOWN, ...headers }),
+		mode, cache, credentials, redirect,  priority, referrerPolicy, signal,
+	});
+
+	if (! resp.ok) {
+		throw new Error(`${resp.url} [${resp.status} ${resp.statusText}]`);
+	} else if (! resp.headers.get('Content-Type').startsWith(MARKDOWN)) {
+		throw new TypeError(`Expected "Content-Type: ${MARKDOWN}" but got ${resp.headers.get('Content-Type')}.`);
+	} else {
+		const text = await resp.text();
+		return await parseMarkdown(text, { base, allowElements, allowAttributes });
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,26 @@
 {
   "name": "@shgysk8zer0/kazoo",
-  "version": "0.0.17",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@shgysk8zer0/kazoo",
-      "version": "0.0.17",
+      "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
         "@shgysk8zer0/js-utils": "^1.0.0",
         "htmlhint": "^1.1.4",
         "http-server": "^14.1.1"
+      }
+    },
+    "node_modules/@aashutoshrathi/word-wrap": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1212,17 +1221,17 @@
       }
     },
     "node_modules/optionator": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
+      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
       "dev": true,
       "dependencies": {
+        "@aashutoshrathi/word-wrap": "^1.2.3",
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
         "levn": "^0.4.1",
         "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0",
-        "word-wrap": "^1.2.3"
+        "type-check": "^0.4.0"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -1723,15 +1732,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -1758,6 +1758,12 @@
     }
   },
   "dependencies": {
+    "@aashutoshrathi/word-wrap": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+      "dev": true
+    },
     "@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -2644,17 +2650,17 @@
       "dev": true
     },
     "optionator": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
+      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
       "dev": true,
       "requires": {
+        "@aashutoshrathi/word-wrap": "^1.2.3",
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
         "levn": "^0.4.1",
         "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0",
-        "word-wrap": "^1.2.3"
+        "type-check": "^0.4.0"
       }
     },
     "p-limit": {
@@ -3017,12 +3023,6 @@
       "requires": {
         "isexe": "^2.0.0"
       }
-    },
-    "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@shgysk8zer0/kazoo",
-  "version": "0.0.17",
+  "version": "0.1.0",
   "private": false,
+  "type": "module",
   "description": "A JavaScript monorepo for all the things!",
   "config": {
     "serve": {
@@ -26,9 +27,9 @@
     "lint:html": "htmlhint \"**/*.html\"",
     "create:lock": "npm i --package-lock-only --ignore-scripts",
     "version:bump": "npm run version:bump:patch",
-    "version:bump:patch": "npm version --no-git-tag-version patch",
-    "version:bump:minor": "npm version --no-git-tag-version minor",
-    "version:bump:major": "npm version --no-git-tag-version major"
+    "version:bump:patch": "npm version --no-git-tag-version patch && npm run create:lock",
+    "version:bump:minor": "npm version --no-git-tag-version minor && npm run create:lock",
+    "version:bump:major": "npm version --no-git-tag-version major && npm run create:lock"
   },
   "repository": {
     "type": "git",

--- a/test/css/index.css
+++ b/test/css/index.css
@@ -54,3 +54,8 @@ dialog::backdrop {
 	background-color: rgba(0, 0, 0, 0.7);
 	backdrop-filter: blur(3px);
 }
+
+pre, code, table, tr, thead, tfoot, img {
+	max-width: 100%;
+	overflow: auto;
+}

--- a/test/index.html
+++ b/test/index.html
@@ -9,8 +9,8 @@
 			base-uri 'self';
 			manifest-src 'self';
 			prefetch-src 'self';
-			script-src 'self' https://unpkg.com/@shgysk8zer0/ https://unpkg.com/leaflet@1.9.3/ 'nonce-3b58877b-25c3-4af2-975f-76607bd7c78e';
-			style-src 'self' https://unpkg.com/@shgysk8zer0/ https://unpkg.com/leaflet@1.9.3/ blob:;
+			script-src 'self' https://unpkg.com/ 'nonce-3b58877b-25c3-4af2-975f-76607bd7c78e';
+			style-src 'self' https://unpkg.com/ blob:;
 			font-src cdn.kernvalley.us;
 			form-action 'none';
 			frame-src https://www.youtube-nocookie.com/embed/;
@@ -19,10 +19,10 @@
 			child-src 'self';
 			worker-src 'self';
 			frame-ancestors 'none';
-			connect-src 'self' https://unpkg.com/@shgysk8zer0/ https://api.github.com/users/ https://api.github.com/repos/ https://api.pwnedpasswords.com/range/ https://maps.kernvalley.us/places/ https://events.kernvalley.us/events.json;
+			connect-src 'self' https://unpkg.com/ https://api.github.com/users/ https://api.github.com/repos/ https://api.pwnedpasswords.com/range/ https://maps.kernvalley.us/places/ https://events.kernvalley.us/events.json;
 			img-src * data: blob:;
 			require-trusted-types-for 'script';
-			trusted-types empty#html empty#script default sanitizer-raw#html youtube#embed github-user#html github-repo#html;
+			trusted-types empty#html empty#script default sanitizer-raw#html trust-raw#html youtube#embed github-user#html github-repo#html;
 			upgrade-insecure-requests;"
 		/>
 		<title>Kazoo</title>
@@ -30,16 +30,25 @@
 		<script type="importmap" nonce="3b58877b-25c3-4af2-975f-76607bd7c78e">
 			{
 				"imports": {
+					"@shgysk8zer0/kazoo/": "../",
+					"@shgysk8zer0/konami": "https://unpkg.com/@shgysk8zer0/konami@1.0.10/konami.js",
 					"@shgysk8zer0/polyfills": "https://unpkg.com/@shgysk8zer0/polyfills@0.1.2/all.min.js",
 					"@shgysk8zer0/polyfills/": "https://unpkg.com/@shgysk8zer0/polyfills@0.1.2/",
-					"@shgysk8zer0/components/": "https://unpkg.com/@shgysk8zer0/components@0.0.9/",
-					"@shgysk8zer0/konami": "https://unpkg.com/@shgysk8zer0/konami@1.1.1/konami.js",
-					"@shgysk8zer0/jswaggersheets": "https://unpkg.com/@shgysk8zer0/jswaggersheets/swagger.js",
-					"@shgysk8zer0/http-status": "https://unpkg.com/@shgysk8zer0/http-status@1.0.1/http-status.js",
-					"@shgysk8zer0/kazoo/": "../",
-					"leaflet": "https://unpkg.com/leaflet@1.9.3/dist/leaflet-src.esm.js",
-					"firebase/": "https://www.gstatic.com/firebasejs/9.16.0/"
-				}
+					"@shgysk8zer0/jswaggersheets": "https://unpkg.com/@shgysk8zer0/jswaggersheets@1.0.4/swagger.js",
+					"@shgysk8zer0/jswaggersheets/": "https://unpkg.com/@shgysk8zer0/jswaggersheets@1.0.4/",
+					"@shgysk8zer0/http-status": "https://unpkg.com/@shgysk8zer0/http-status@1.0.2/http-status.js",
+					"@shgysk8zer0/components/": "https://unpkg.com/@shgysk8zer0/components@0.0.12/",
+					"@kernvalley/components/": "https://unpkg.com/@kernvalley/components@1.0.2/",
+					"@webcomponents/custom-elements": "https://unpkg.com/@webcomponents/custom-elements@1.6.0/custom-elements.min.js",
+					"leaflet": "https://unpkg.com/leaflet@1.9.4/dist/leaflet-src.esm.js",
+					"firebase/": "https://www.gstatic.com/firebasejs/9.22.2/",
+					"urlpattern-polyfill": "https://unpkg.com/urlpattern-polyfill@9.0.0/index.js",
+					"highlight.js": "https://unpkg.com/@highlightjs/cdn-assets@11.8.0/es/highlight.min.js",
+					"highlight.js/": "https://unpkg.com/@highlightjs/cdn-assets@11.8.0/",
+					"marked": "https://unpkg.com/marked@5.1.0/src/marked.js",
+					"marked-highlight": "https://unpkg.com/marked-highlight@2.0.1/src/index.js"
+				},
+				"scope": {}
 			}
 		</script>
 		<script type="application/javascript" defer="" referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha384-8s5Tj7IrKDs3va2EJ3QsRxxApN9vT+thnbA8imc6bwYJA2JaAddVR5b8q5wDkrdv" src="https://unpkg.com/@shgysk8zer0/polyfills@0.1.2/all.min.js" fetchpriority="high"></script>

--- a/types.js
+++ b/types.js
@@ -13,5 +13,6 @@ export const PNG = 'image/png';
 export const GIF = 'image/gif';
 export const WEBP = 'image/webp';
 export const SVG = 'image/svg+xml';
+export const MARKDOWN = 'text/markdown';
 export const FORM_URL_ENCODED = 'application/x-www-form-urlencoded';
 export const FORM_MULTIPART = 'multipart/form-data';


### PR DESCRIPTION
**Added**
- Add `markdown` module
- Add `isSafeHTML()` to `trust-policies` module (checks for unsafe elements & attributes)
- Add `getCSSStyleSheet()` to `http` module
- Add Markdown to `types` module
- Add `gravatar` module

**Changed**
- Rename `loadStylesheet()` -> `loadStyleSheet()` in `loader` module (with alias to old)
- Update importmap and trusted policies

**Deprecated**
- `loadStylesheet()` is deprecated

# Description and issue

## List of significant changes made
-  
-  
